### PR TITLE
Even when object is not null, this error is thrown

### DIFF
--- a/lib/src/main/java/com/vincentbrison/openlibraries/android/dualcache/lib/CustomLruCache.java
+++ b/lib/src/main/java/com/vincentbrison/openlibraries/android/dualcache/lib/CustomLruCache.java
@@ -164,7 +164,7 @@ public class CustomLruCache<K, V> {
      */
     public final V put(K key, V value) {
         if (key == null || value == null) {
-            throw new NullPointerException("key == null || value == null");
+            throw new NullPointerException("key == null || value == null. This could happen even if you supplied a non-null object, but it couldn't be serialised.");
         }
 
         V previous;


### PR DESCRIPTION
- When I ran this for a non-null object of a custom class, this error was thrown. A thorough debugger session has shown that the object wasn't null, but that the serialiser was unable to serialise the object, and hence this misleading error was thrown.

I was using a non-null object of this class:

```
public class UsersMultiple {
    private User[] mUsers;

    public UsersMultiple(User[] mUsers) {
        this.mUsers = mUsers;
    }

    public User[] getmUsers() {
        return mUsers;
    }
}
```